### PR TITLE
Make kernel compile on newer platforms

### DIFF
--- a/platform/linux/arch/mips/kernel/mips_ksyms.c
+++ b/platform/linux/arch/mips/kernel/mips_ksyms.c
@@ -34,6 +34,9 @@ EXPORT_SYMBOL(memmove);
 
 EXPORT_SYMBOL(kernel_thread);
 
+EXPORT_SYMBOL(clear_page);
+EXPORT_SYMBOL(copy_page);
+
 /*
  * Userspace access stuff.
  */

--- a/platform/linux/arch/mips/mm/Makefile
+++ b/platform/linux/arch/mips/mm/Makefile
@@ -3,7 +3,7 @@
 #
 
 obj-y				+= cache.o dma-default.o extable.o fault.o \
-				   init.o tlbex.o tlbex-fault.o uasm.o page.o
+				   init.o page-funcs.o tlbex.o tlbex-fault.o uasm.o page.o
 
 obj-$(CONFIG_32BIT)		+= ioremap.o pgtable-32.o
 obj-$(CONFIG_64BIT)		+= pgtable-64.o

--- a/platform/linux/arch/mips/mm/page-funcs.S
+++ b/platform/linux/arch/mips/mm/page-funcs.S
@@ -1,0 +1,50 @@
+/* This file is subject to the terms and conditions of the GNU General Public 
+ * License.  See the file "COPYING" in the main directory of this archive 
+ * for more details. 
+ * 
+ * Micro-assembler generated clear_page/copy_page functions. 
+ * 
+ * Copyright (C) 2012  MIPS Technologies, Inc. 
+ * Copyright (C) 2012  Ralf Baechle <ralf@linux-mips.org> 
+ */ 
+#include <asm/asm.h> 
+#include <asm/regdef.h> 
+ 
+#ifdef CONFIG_SIBYTE_DMA_PAGEOPS 
+#define cpu_clear_page_function_name    clear_page_cpu 
+#define cpu_copy_page_function_name     copy_page_cpu 
+#else 
+#define cpu_clear_page_function_name    clear_page 
+#define cpu_copy_page_function_name     copy_page 
+#endif 
+ 
+/* 
+ * Maximum sizes: 
+ * 
+ * R4000 128 bytes S-cache:             0x058 bytes 
+ * R4600 v1.7:                          0x05c bytes 
+ * R4600 v2.0:                          0x060 bytes 
+ * With prefetching, 16 word strides    0x120 bytes 
+ */ 
+EXPORT(__clear_page_start) 
+LEAF(cpu_clear_page_function_name) 
+1:      j       1b              /* Dummy, will be replaced. */ 
+        .space 288 
+END(cpu_clear_page_function_name) 
+EXPORT(__clear_page_end) 
+ 
+/* 
+ * Maximum sizes: 
+ * 
+ * R4000 128 bytes S-cache:             0x11c bytes 
+ * R4600 v1.7:                          0x080 bytes 
+ * R4600 v2.0:                          0x07c bytes 
+ * With prefetching, 16 word strides    0x540 bytes 
+ */ 
+EXPORT(__copy_page_start) 
+LEAF(cpu_copy_page_function_name) 
+1:      j       1b              /* Dummy, will be replaced. */ 
+        .space 1344 
+END(cpu_copy_page_function_name) 
+EXPORT(__copy_page_end) 
+

--- a/platform/linux/arch/mips/mm/page.c
+++ b/platform/linux/arch/mips/mm/page.c
@@ -72,44 +72,6 @@ static struct uasm_reloc __cpuinitdata relocs[5];
 #define cpu_is_r4600_v1_x()	((read_c0_prid() & 0xfffffff0) == 0x00002010)
 #define cpu_is_r4600_v2_x()	((read_c0_prid() & 0xfffffff0) == 0x00002020)
 
-/*
- * Maximum sizes:
- *
- * R4000 128 bytes S-cache:		0x058 bytes
- * R4600 v1.7:				0x05c bytes
- * R4600 v2.0:				0x060 bytes
- * With prefetching, 16 word strides	0x120 bytes
- */
-
-static u32 clear_page_array[0x120 / 4];
-
-#ifdef CONFIG_SIBYTE_DMA_PAGEOPS
-void clear_page_cpu(void *page) __attribute__((alias("clear_page_array")));
-#else
-void clear_page(void *page) __attribute__((alias("clear_page_array")));
-#endif
-
-EXPORT_SYMBOL(clear_page);
-
-/*
- * Maximum sizes:
- *
- * R4000 128 bytes S-cache:		0x11c bytes
- * R4600 v1.7:				0x080 bytes
- * R4600 v2.0:				0x07c bytes
- * With prefetching, 16 word strides	0x540 bytes
- */
-static u32 copy_page_array[0x540 / 4];
-
-#ifdef CONFIG_SIBYTE_DMA_PAGEOPS
-void
-copy_page_cpu(void *to, void *from) __attribute__((alias("copy_page_array")));
-#else
-void copy_page(void *to, void *from) __attribute__((alias("copy_page_array")));
-#endif
-
-EXPORT_SYMBOL(copy_page);
-
 
 static int pref_bias_clear_store __cpuinitdata;
 static int pref_bias_copy_load __cpuinitdata;
@@ -288,10 +250,15 @@ static inline void __cpuinit build_clear_pref(u32 **buf, int off)
 		}
 }
 
+extern u32 __clear_page_start;
+extern u32 __clear_page_end;
+extern u32 __copy_page_start;
+extern u32 __copy_page_end;
+
 void __cpuinit build_clear_page(void)
 {
 	int off;
-	u32 *buf = (u32 *)&clear_page_array;
+	u32 *buf = &__clear_page_start;
 	struct uasm_label *l = labels;
 	struct uasm_reloc *r = relocs;
 	int i;
@@ -395,17 +362,17 @@ void __cpuinit build_clear_page(void)
 	uasm_i_jr(&buf, RA);
 	uasm_i_nop(&buf);
 
-	BUG_ON(buf > clear_page_array + ARRAY_SIZE(clear_page_array));
+	BUG_ON(buf > &__clear_page_end);
 
 	uasm_resolve_relocs(relocs, labels);
 
 	pr_debug("Synthesized clear page handler (%u instructions).\n",
-		 (u32)(buf - clear_page_array));
+		 (u32)(buf - &__clear_page_start));
 
 	pr_debug("\t.set push\n");
 	pr_debug("\t.set noreorder\n");
-	for (i = 0; i < (buf - clear_page_array); i++)
-		pr_debug("\t.word 0x%08x\n", clear_page_array[i]);
+	for (i = 0; i < (buf - &__clear_page_start); i++)
+		pr_debug("\t.word 0x%08x\n", (&__clear_page_start)[i]);
 	pr_debug("\t.set pop\n");
 }
 
@@ -466,7 +433,7 @@ static inline void build_copy_store_pref(u32 **buf, int off)
 void __cpuinit build_copy_page(void)
 {
 	int off;
-	u32 *buf = (u32 *)&copy_page_array;
+	u32 *buf = &__copy_page_start;
 	struct uasm_label *l = labels;
 	struct uasm_reloc *r = relocs;
 	int i;
@@ -634,21 +601,24 @@ void __cpuinit build_copy_page(void)
 	uasm_i_jr(&buf, RA);
 	uasm_i_nop(&buf);
 
-	BUG_ON(buf > copy_page_array + ARRAY_SIZE(copy_page_array));
+	BUG_ON(buf > &__copy_page_end);
 
 	uasm_resolve_relocs(relocs, labels);
 
 	pr_debug("Synthesized copy page handler (%u instructions).\n",
-		 (u32)(buf - copy_page_array));
+		 (u32)(buf - &__copy_page_start));
 
 	pr_debug("\t.set push\n");
 	pr_debug("\t.set noreorder\n");
-	for (i = 0; i < (buf - copy_page_array); i++)
-		pr_debug("\t.word 0x%08x\n", copy_page_array[i]);
+	for (i = 0; i < (buf - &__copy_page_start); i++)
+		pr_debug("\t.word 0x%08x\n", (&__copy_page_start)[i]);
 	pr_debug("\t.set pop\n");
 }
 
 #ifdef CONFIG_SIBYTE_DMA_PAGEOPS
+
+extern void clear_page_cpu(void *page);
+extern void copy_page_cpu(void *to, void *from);
 
 /*
  * Pad descriptors to cacheline, since each is exclusively owned by a

--- a/platform/linux/kernel/timeconst.pl
+++ b/platform/linux/kernel/timeconst.pl
@@ -369,10 +369,8 @@ if ($hz eq '--can') {
 		die "Usage: $0 HZ\n";
 	}
 
-	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
-		@val = compute_values($hz);
-	}
+	$cv = $canned_values{$hz};
+	@val = defined($cv) ? @$cv : compute_values($hz);
 	output($hz, @val);
 }
 exit 0;


### PR DESCRIPTION
Patches necessary for the kernel to compile on newer compilation platforms, split into two parts, the first one has to do with C and is based on <https://dev.openwrt.org/browser/trunk/target/linux/generic/patches-3.3/003-MIPS-Refactor-clear_page-and-copy_page-functions.patch?rev=40619> and the other with `perl` and is based on <https://bug1231340.bmoattachments.org/attachment.cgi?id=8697580>.

This does only concern compilation of the kernel not other parts. For e.g. `busybox` other changes would be necessary, e.g. for the _"mixed implicit and normal rules"_ `make` error to go away see <http://stackoverflow.com/a/13945900>.